### PR TITLE
added missing punctuation mark

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable operator_roles_properties {
     }))
     validation {
       condition     = length(var.operator_roles_properties) == 6
-      error_message = "The list of operator roles should contains 6 elements"
+      error_message = "The list of operator roles should contains 6 elements."
     }
 
 }


### PR DESCRIPTION
Fixing missing punctuation mark, this operator-roles module is being referenced by the ocm provider and is causing issues there. 