### PR TITLE
add option to pass tags as parameter to apply to aws resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,19 @@ This terraform module tries to replicate rosa CLI roles creation so that:
 |ocm_environment| string      |  the OCM environments. The value should be one of those: production, staging, integration, local                                                                                                                                                  | "production"       |
 |account_role_policies| object      | account role policies details for account roles creation                                       | [an example can be found below](https://github.com/terraform-redhat/terraform-aws-rosa-sts/tree/use_data_source_for_account_policies/account_roles_creation#account_role_policies-object)  |
 |operator_role_policies| object      | operator role policies details for operator role policies creation                             | [an example can be found below](https://github.com/terraform-redhat/terraform-aws-rosa-sts/tree/use_data_source_for_account_policies/account_roles_creation#operator_role_policies-object) |
-|tags | map of strings |List of aws resource tags to apply | [an example can be found in examples folder](https://github.com/StateFarmIns/terraform-aws-rosa-sts/blob/main/examples/operator_roles_and_oidc/variables.tf#L32-41)
+|tags | map of strings |List of AWS resource tags to apply | [an example can be found below](#tags-object) |
+
+### tags object
+`tags` is a map of strings with resource tags to be applied to AWS resources created.
+The map looks like:
+```
+{
+  contact     = "xyz@company.com"
+  cost-center = "12345"
+  owner       = "productteam"
+  environment = "test"
+}
+```
 
 ## Get OCM Information for operator roles and OIDC provider
 
@@ -168,6 +180,14 @@ module "create_account_roles"{
    rosa_openshift_version = var.rosa_openshift_version
    account_role_policies = var.account_role_policies
    operator_role_policies = var.operator_role_policies
+
+    #optional
+    tags                = {
+      contact     = "xyz@company.com"
+      cost-center = "12345"
+      owner       = "productteam"
+      environment = "test"
+    }
 }
 ```
 
@@ -191,6 +211,14 @@ module operator_roles {
     rh_oidc_provider_thumbprint = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.thumbprint
     rh_oidc_provider_url = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
     operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+
+    #optional
+    tags                = {
+      contact     = "xyz@company.com"
+      cost-center = "12345"
+      owner       = "productteam"
+      environment = "test"
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This terraform module tries to replicate rosa CLI roles creation so that:
 |ocm_environment| string      |  the OCM environments. The value should be one of those: production, staging, integration, local                                                                                                                                                  | "production"       |
 |account_role_policies| object      | account role policies details for account roles creation                                       | [an example can be found below](https://github.com/terraform-redhat/terraform-aws-rosa-sts/tree/use_data_source_for_account_policies/account_roles_creation#account_role_policies-object)  |
 |operator_role_policies| object      | operator role policies details for operator role policies creation                             | [an example can be found below](https://github.com/terraform-redhat/terraform-aws-rosa-sts/tree/use_data_source_for_account_policies/account_roles_creation#operator_role_policies-object) |
-
+|tags | map of strings |List of aws resource tags to apply | [an example can be found in examples folder](https://github.com/StateFarmIns/terraform-aws-rosa-sts/blob/main/examples/operator_roles_and_oidc/variables.tf#L32-41)
 
 ## Get OCM Information for operator roles and OIDC provider
 

--- a/account_roles_creation/README.md
+++ b/account_roles_creation/README.md
@@ -17,6 +17,19 @@ Terraform AWS ROSA STS
 |ocm_environment| string      | the OCM environments. The value should be one of those: production, staging, integration, local | "production"                                                                                                                                                                        |
 |account_role_policies| object      | account role policies details for account roles creation                                       | [an example can be found below](https://github.com/terraform-redhat/terraform-aws-rosa-sts/tree/use_data_source_for_account_policies/account_roles_creation#account_role_policies-object)  |
 |operator_role_policies| object      | operator role policies details for operator role policies creation                             | [an example can be found below](https://github.com/terraform-redhat/terraform-aws-rosa-sts/tree/use_data_source_for_account_policies/account_roles_creation#operator_role_policies-object) |
+|tags | map of strings | List of AWS resource tags to apply | [an example can be found below](#tags-object) |
+
+### tags object
+`tags` is a map of strings with resource tags to be applied to AWS resources created.
+The map looks like:
+```
+{
+  contact     = "xyz@company.com"
+  cost-center = "12345"
+  owner       = "productteam"
+  environment = "test"
+}
+```
 
 ### account_role_policies object
 `account_role_policies` is an object that holds the policy details for each account role. 
@@ -44,6 +57,17 @@ The object looks like:
   "openshift_image_registry_installer_cloud_credentials_policy" = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\",\"Action\": [], \"Resource\": \"*\"}]}"
   "openshift_ingress_operator_cloud_credentials_policy" = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\",\"Action\": [], \"Resource\": \"*\"}]}"
   "openshift_machine_api_aws_cloud_credentials_policy" = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\",\"Action\": [], \"Resource\": \"*\"}]}"
+}
+```
+### tags object
+`tags` is a map of strings with resource tags to be applied to AWS resources created.
+The map looks like:
+```
+{
+  contact     = "xyz@company.com"
+  cost-center = "12345"
+  owner       = "productteam"
+  environment = "test"
 }
 ```
 

--- a/account_roles_creation/README.md
+++ b/account_roles_creation/README.md
@@ -59,17 +59,6 @@ The object looks like:
   "openshift_machine_api_aws_cloud_credentials_policy" = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\",\"Action\": [], \"Resource\": \"*\"}]}"
 }
 ```
-### tags object
-`tags` is a map of strings with resource tags to be applied to AWS resources created.
-The map looks like:
-```
-{
-  contact     = "xyz@company.com"
-  cost-center = "12345"
-  owner       = "productteam"
-  environment = "test"
-}
-```
 
 ## Usage
 
@@ -77,18 +66,26 @@ The map looks like:
 
 ```
 module "create_account_roles"{
-   source = "terraform-redhat/rosa-sts/aws"
-   version = ">=0.0.3"
+  source = "terraform-redhat/rosa-sts/aws"
+  version = ">=0.0.3"
 
-   create_operator_roles = false
-   create_oidc_provider = false
-   create_account_roles = true
+  create_operator_roles = false
+  create_oidc_provider = false
+  create_account_roles = true
 
-   account_role_prefix = var.account_role_prefix
-   ocm_environment = var.ocm_environment
-   rosa_openshift_version = var.rosa_openshift_version
-   account_role_policies = var.account_role_policies
-   operator_role_policies = var.operator_role_policies
+  account_role_prefix = var.account_role_prefix
+  ocm_environment = var.ocm_environment
+  rosa_openshift_version = var.rosa_openshift_version
+  account_role_policies = var.account_role_policies
+  operator_role_policies = var.operator_role_policies
+
+  #optional
+  tags                = {
+    contact     = "xyz@company.com"
+    cost-center = "12345"
+    owner       = "productteam"
+    environment = "test"
+  }
 }
 ```
 

--- a/account_roles_creation/account_role/account_role_resource.tf
+++ b/account_roles_creation/account_role/account_role_resource.tf
@@ -14,22 +14,22 @@ resource "aws_iam_role" "account_role" {
     ]
   })
 
-  tags = {
+  tags = merge(var.tags, {
     rosa_openshift_version = var.rosa_openshift_version
-    rosa_role_prefix = "${var.account_role_prefix}"
-    rosa_role_type = "${var.account_role_properties.role_type}"
-  }
+    rosa_role_prefix       = "${var.account_role_prefix}"
+    rosa_role_type         = "${var.account_role_properties.role_type}"
+  })
 }
 
 # policy
 resource "aws_iam_policy" "account_role_policy" {
-  name        = "${var.account_role_prefix}-${var.account_role_properties.role_name}-Role-Policy"
+  name   = "${var.account_role_prefix}-${var.account_role_properties.role_name}-Role-Policy"
   policy = var.account_role_properties.policy_details
-  tags = {
+  tags = merge(var.tags, {
     rosa_openshift_version = var.rosa_openshift_version
-    rosa_role_prefix = "${var.account_role_prefix}"
-    rosa_role_type = "${var.account_role_properties.role_type}"
-  }
+    rosa_role_prefix       = "${var.account_role_prefix}"
+    rosa_role_type         = "${var.account_role_properties.role_type}"
+  })
 }
 
 

--- a/account_roles_creation/account_role/instance_account_role_resource.tf
+++ b/account_roles_creation/account_role/instance_account_role_resource.tf
@@ -15,22 +15,22 @@ resource "aws_iam_role" "instance_account_role" {
     ]
   })
 
-  tags = {
+  tags = merge(var.tags, {
     rosa_openshift_version = var.rosa_openshift_version
-    rosa_role_prefix = "${var.account_role_prefix}"
-    rosa_role_type = "instance_${var.instance_account_role_properties.role_type}"
-  }
+    rosa_role_prefix       = "${var.account_role_prefix}"
+    rosa_role_type         = "instance_${var.instance_account_role_properties.role_type}"
+  })
 }
 
 # policy
 resource "aws_iam_policy" "instance_account_role_policy" {
-  name        = "${var.account_role_prefix}-${var.instance_account_role_properties.role_name}-Role-Policy"
+  name   = "${var.account_role_prefix}-${var.instance_account_role_properties.role_name}-Role-Policy"
   policy = var.instance_account_role_properties.policy_details
-  tags = {
+  tags = merge(var.tags, {
     rosa_openshift_version = var.rosa_openshift_version
-    rosa_role_prefix = "${var.account_role_prefix}"
-    rosa_role_type = "instance_${var.instance_account_role_properties.role_type}"
-  }
+    rosa_role_prefix       = "${var.account_role_prefix}"
+    rosa_role_type         = "instance_${var.instance_account_role_properties.role_type}"
+  })
 }
 
 

--- a/account_roles_creation/account_role/variables.tf
+++ b/account_roles_creation/account_role/variables.tf
@@ -1,30 +1,36 @@
-variable account_role_prefix {
-    type = string
+variable "account_role_prefix" {
+  type = string
 }
 
-variable account_role_properties {
-    description = "Account IAM role properties"
-    type = object({
-            role_name = string
-            role_type = string
-            principal = string
-            policy_details = string
-        })
+variable "account_role_properties" {
+  description = "Account IAM role properties"
+  type = object({
+    role_name      = string
+    role_type      = string
+    principal      = string
+    policy_details = string
+  })
 }
 
-variable instance_account_role_properties {
-    description = "Account IAM role properties"
-    type = object({
-            role_name = string
-            role_type = string
-            policy_details = string
-        })
+variable "instance_account_role_properties" {
+  description = "Account IAM role properties"
+  type = object({
+    role_name      = string
+    role_type      = string
+    policy_details = string
+  })
 }
 
-variable rosa_openshift_version {
-    type = string
-    default = "4.12"
+variable "rosa_openshift_version" {
+  type    = string
+  default = "4.12"
 }
-variable account_id {
-    type = string
+variable "account_id" {
+  type = string
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }

--- a/account_roles_creation/account_role/variables.tf
+++ b/account_roles_creation/account_role/variables.tf
@@ -30,7 +30,7 @@ variable "account_id" {
 }
 
 variable "tags" {
-  description = "List of aws resource tags to apply."
+  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
 }

--- a/account_roles_creation/main.tf
+++ b/account_roles_creation/main.tf
@@ -7,96 +7,98 @@ terraform {
   }
 }
 
-module rosa_account_roles {
-    source = "./account_role"
-    count = 2
+module "rosa_account_roles" {
+  source = "./account_role"
+  count  = 2
 
-    account_role_prefix = var.account_role_prefix
-    rosa_openshift_version = var.rosa_openshift_version
-    account_role_properties = local.account_roles_properties[count.index]
-    instance_account_role_properties = local.instance_account_roles_properties[count.index]
-    account_id = lookup({"production"="710019948333", "staging"="644306948063", "integration"="896164604406", "local"="765374464689"}, var.ocm_environment, "710019948333")
+  account_role_prefix              = var.account_role_prefix
+  rosa_openshift_version           = var.rosa_openshift_version
+  account_role_properties          = local.account_roles_properties[count.index]
+  instance_account_role_properties = local.instance_account_roles_properties[count.index]
+  account_id                       = lookup({ "production" = "710019948333", "staging" = "644306948063", "integration" = "896164604406", "local" = "765374464689" }, var.ocm_environment, "710019948333")
+  tags                             = var.tags
 }
 
-module rosa_operator_role_policies {
-    source = "./operator_role_policy"
-    count = 6
+module "rosa_operator_role_policies" {
+  source = "./operator_role_policy"
+  count  = 6
 
-    account_role_prefix = var.account_role_prefix
-    rosa_openshift_version = var.rosa_openshift_version
-    operator_role_policy_properties = local.operator_roles_policy_properties[count.index]
+  account_role_prefix             = var.account_role_prefix
+  rosa_openshift_version          = var.rosa_openshift_version
+  operator_role_policy_properties = local.operator_roles_policy_properties[count.index]
+  tags                            = var.tags
 }
 
 locals {
-    account_roles_properties = [{
-        # installer
-        role_name = "Installer"
-        role_type = "installer"
-        principal = "RH-Managed-OpenShift-Installer"
-        policy_details = var.account_role_policies["sts_installer_permission_policy"]
+  account_roles_properties = [{
+    # installer
+    role_name      = "Installer"
+    role_type      = "installer"
+    principal      = "RH-Managed-OpenShift-Installer"
+    policy_details = var.account_role_policies["sts_installer_permission_policy"]
     },
     {
-       # support
-       role_name = "Support"
-       role_type = "support"
-       principal = "RH-Technical-Support-Access"
+      # support
+      role_name      = "Support"
+      role_type      = "support"
+      principal      = "RH-Technical-Support-Access"
       policy_details = var.account_role_policies["sts_support_permission_policy"]
-    }]
+  }]
 
-    instance_account_roles_properties = [{
-       # worker
-       role_name = "Worker"
-       role_type = "worker"
-       policy_details = var.account_role_policies["sts_instance_worker_permission_policy"]
+  instance_account_roles_properties = [{
+    # worker
+    role_name      = "Worker"
+    role_type      = "worker"
+    policy_details = var.account_role_policies["sts_instance_worker_permission_policy"]
     },
     {
-       # control plan
-       role_name = "ControlPlane"
-       role_type = "controlplane"
-       policy_details = var.account_role_policies["sts_instance_controlplane_permission_policy"]
-    }]
+      # control plan
+      role_name      = "ControlPlane"
+      role_type      = "controlplane"
+      policy_details = var.account_role_policies["sts_instance_controlplane_permission_policy"]
+  }]
 
-    # TODO: if there is a new policy for a new OCP versions, need to add it here also
-    operator_roles_policy_properties = [{
-        # openshift-machine-api
-        policy_name = substr("${var.account_role_prefix}-openshift-cloud-network-config-controller-cloud-credentials", 0, 64)
-        policy_details = var.operator_role_policies["openshift_cloud_network_config_controller_cloud_credentials_policy"]
-        namespace = "openshift-cloud-network-config-controller"
-        operator_name = "cloud-credentials"
+  # TODO: if there is a new policy for a new OCP versions, need to add it here also
+  operator_roles_policy_properties = [{
+    # openshift-machine-api
+    policy_name    = substr("${var.account_role_prefix}-openshift-cloud-network-config-controller-cloud-credentials", 0, 64)
+    policy_details = var.operator_role_policies["openshift_cloud_network_config_controller_cloud_credentials_policy"]
+    namespace      = "openshift-cloud-network-config-controller"
+    operator_name  = "cloud-credentials"
     },
     {
-        # openshift-cloud-credential-operator
-        policy_name = substr("${var.account_role_prefix}-openshift-machine-api-aws-cloud-credentials", 0, 64)
-        policy_details = var.operator_role_policies["openshift_machine_api_aws_cloud_credentials_policy"]
-        namespace = "openshift-machine-api"
-        operator_name = "aws-cloud-credentials"
+      # openshift-cloud-credential-operator
+      policy_name    = substr("${var.account_role_prefix}-openshift-machine-api-aws-cloud-credentials", 0, 64)
+      policy_details = var.operator_role_policies["openshift_machine_api_aws_cloud_credentials_policy"]
+      namespace      = "openshift-machine-api"
+      operator_name  = "aws-cloud-credentials"
     },
     {
-        # openshift-cloud-network-config-controller
-        policy_name = substr("${var.account_role_prefix}-openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds", 0, 64)
-        policy_details = var.operator_role_policies["openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy"]
-        namespace = "openshift-cloud-credential-operator"
-        operator_name = "cloud-credential-operator-iam-ro-creds"
+      # openshift-cloud-network-config-controller
+      policy_name    = substr("${var.account_role_prefix}-openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds", 0, 64)
+      policy_details = var.operator_role_policies["openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy"]
+      namespace      = "openshift-cloud-credential-operator"
+      operator_name  = "cloud-credential-operator-iam-ro-creds"
     },
     {
-        # openshift-image-registry
-        policy_name = substr("${var.account_role_prefix}-openshift-image-registry-installer-cloud-credentials", 0, 64)
-        policy_details = var.operator_role_policies["openshift_image_registry_installer_cloud_credentials_policy"]
-        namespace = "openshift-image-registry"
-        operator_name = "installer-cloud-credentials"
+      # openshift-image-registry
+      policy_name    = substr("${var.account_role_prefix}-openshift-image-registry-installer-cloud-credentials", 0, 64)
+      policy_details = var.operator_role_policies["openshift_image_registry_installer_cloud_credentials_policy"]
+      namespace      = "openshift-image-registry"
+      operator_name  = "installer-cloud-credentials"
     },
     {
-        # openshift-ingress-operator
-        policy_name = substr("${var.account_role_prefix}-openshift-ingress-operator-cloud-credentials", 0, 64)
-        policy_details = var.operator_role_policies["openshift_ingress_operator_cloud_credentials_policy"]
-        namespace = "openshift-ingress-operator"
-        operator_name = "cloud-credentials"
+      # openshift-ingress-operator
+      policy_name    = substr("${var.account_role_prefix}-openshift-ingress-operator-cloud-credentials", 0, 64)
+      policy_details = var.operator_role_policies["openshift_ingress_operator_cloud_credentials_policy"]
+      namespace      = "openshift-ingress-operator"
+      operator_name  = "cloud-credentials"
     },
     {
-        # openshift-cluster-csi-drivers
-        policy_name = substr("${var.account_role_prefix}-openshift-cluster-csi-drivers-ebs-cloud-credentials", 0, 64)
-        policy_details = var.operator_role_policies["openshift_cluster_csi_drivers_ebs_cloud_credentials_policy"]
-        namespace = "openshift-cluster-csi-drivers"
-        operator_name = "ebs-cloud-credentials"
-    }]
+      # openshift-cluster-csi-drivers
+      policy_name    = substr("${var.account_role_prefix}-openshift-cluster-csi-drivers-ebs-cloud-credentials", 0, 64)
+      policy_details = var.operator_role_policies["openshift_cluster_csi_drivers_ebs_cloud_credentials_policy"]
+      namespace      = "openshift-cluster-csi-drivers"
+      operator_name  = "ebs-cloud-credentials"
+  }]
 }

--- a/account_roles_creation/operator_role_policy/operator_policy.tf
+++ b/account_roles_creation/operator_role_policy/operator_policy.tf
@@ -1,11 +1,11 @@
 resource "aws_iam_policy" "operator-policy" {
-  name        = "${var.operator_role_policy_properties.policy_name}"
+  name   = var.operator_role_policy_properties.policy_name
   policy = var.operator_role_policy_properties.policy_details
 
-  tags = {
-    rosa_openshift_version="${var.rosa_openshift_version}"
-    rosa_role_prefix="${var.account_role_prefix}"
-    operator_namespace="${var.operator_role_policy_properties.namespace}"
-    operator_name="${var.operator_role_policy_properties.operator_name}"
-  }
+  tags = merge(var.tags, {
+    rosa_openshift_version = "${var.rosa_openshift_version}"
+    rosa_role_prefix       = "${var.account_role_prefix}"
+    operator_namespace     = "${var.operator_role_policy_properties.namespace}"
+    operator_name          = "${var.operator_role_policy_properties.operator_name}"
+  })
 }

--- a/account_roles_creation/operator_role_policy/variables.tf
+++ b/account_roles_creation/operator_role_policy/variables.tf
@@ -1,18 +1,24 @@
-variable account_role_prefix {
-    type = string
+variable "account_role_prefix" {
+  type = string
 }
 
-variable operator_role_policy_properties {
-    description = "Account IAM role properties"
-    type = object({
-            policy_name = string
-            policy_details = string
-            namespace = string
-            operator_name = string
-        })
+variable "operator_role_policy_properties" {
+  description = "Account IAM role properties"
+  type = object({
+    policy_name    = string
+    policy_details = string
+    namespace      = string
+    operator_name  = string
+  })
 }
 
-variable rosa_openshift_version {
-    type = string
-    default = "4.12"
+variable "rosa_openshift_version" {
+  type    = string
+  default = "4.12"
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }

--- a/account_roles_creation/operator_role_policy/variables.tf
+++ b/account_roles_creation/operator_role_policy/variables.tf
@@ -18,7 +18,7 @@ variable "rosa_openshift_version" {
 }
 
 variable "tags" {
-  description = "List of aws resource tags to apply."
+  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
 }

--- a/account_roles_creation/variables.tf
+++ b/account_roles_creation/variables.tf
@@ -1,45 +1,51 @@
-variable account_role_prefix {
-    type = string
-    default = ""
+variable "account_role_prefix" {
+  type    = string
+  default = ""
 }
 
-variable rosa_openshift_version {
-    type = string
-    default = "4.12"
+variable "rosa_openshift_version" {
+  type    = string
+  default = "4.12"
 }
 
-variable ocm_environment {
-    description = "the OCM environments. The value should be one of those: production, staging, integration, local"
-    type = string
-     validation {
-        condition = anytrue([
-          var.ocm_environment == "production",
-          var.ocm_environment == "staging",
-          var.ocm_environment == "integration",
-          var.ocm_environment == "local",
-        ])
-        error_message = "The OCM environment value should be one of those: production, staging, integration, local."
-     }
+variable "ocm_environment" {
+  description = "the OCM environments. The value should be one of those: production, staging, integration, local"
+  type        = string
+  validation {
+    condition = anytrue([
+      var.ocm_environment == "production",
+      var.ocm_environment == "staging",
+      var.ocm_environment == "integration",
+      var.ocm_environment == "local",
+    ])
+    error_message = "The OCM environment value should be one of those: production, staging, integration, local."
+  }
 }
 
-variable account_role_policies {
+variable "account_role_policies" {
   description = "account role policies details for account roles creation"
-  type =object({
-    sts_installer_permission_policy = string
-    sts_support_permission_policy = string
-    sts_instance_worker_permission_policy = string
+  type = object({
+    sts_installer_permission_policy             = string
+    sts_support_permission_policy               = string
+    sts_instance_worker_permission_policy       = string
     sts_instance_controlplane_permission_policy = string
   })
 }
 
-variable operator_role_policies {
+variable "operator_role_policies" {
   description = "operator role policies details for operator roles creation"
-  type =object({
+  type = object({
     openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy = string
-    openshift_cloud_network_config_controller_cloud_credentials_policy = string
-    openshift_cluster_csi_drivers_ebs_cloud_credentials_policy = string
-    openshift_image_registry_installer_cloud_credentials_policy = string
-    openshift_ingress_operator_cloud_credentials_policy = string
-    openshift_machine_api_aws_cloud_credentials_policy = string
+    openshift_cloud_network_config_controller_cloud_credentials_policy                = string
+    openshift_cluster_csi_drivers_ebs_cloud_credentials_policy                        = string
+    openshift_image_registry_installer_cloud_credentials_policy                       = string
+    openshift_ingress_operator_cloud_credentials_policy                               = string
+    openshift_machine_api_aws_cloud_credentials_policy                                = string
   })
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }

--- a/account_roles_creation/variables.tf
+++ b/account_roles_creation/variables.tf
@@ -45,7 +45,7 @@ variable "operator_role_policies" {
 }
 
 variable "tags" {
-  description = "List of aws resource tags to apply."
+  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
 }

--- a/examples/account_roles/create_account_roles.tf
+++ b/examples/account_roles/create_account_roles.tf
@@ -8,15 +8,16 @@ terraform {
 }
 
 
-module "create_account_roles"{
-   source = "terraform-redhat/rosa-sts/aws"
-   version = "0.0.4"
+module "create_account_roles" {
+  source  = "terraform-redhat/rosa-sts/aws"
+  version = "0.0.4"
 
-   create_operator_roles = false
-   create_oidc_provider = false
-   create_account_roles = true
+  create_operator_roles = false
+  create_oidc_provider  = false
+  create_account_roles  = true
 
-   account_role_prefix = var.account_role_prefix
-   ocm_environment = var.ocm_environment
+  account_role_prefix = var.account_role_prefix
+  ocm_environment     = var.ocm_environment
+  tags                = var.tags
 }
 

--- a/examples/account_roles/variables.tf
+++ b/examples/account_roles/variables.tf
@@ -8,7 +8,7 @@ variable "ocm_environment" {
 }
 
 variable "tags" {
-  description = "(optional) List of aws resource tags to apply."
+  description = "(optional) List of AWS resource tags to apply."
   type        = map(string)
   default = {
     contact     = "xyz@company.com"

--- a/examples/account_roles/variables.tf
+++ b/examples/account_roles/variables.tf
@@ -1,8 +1,19 @@
-variable account_role_prefix {
-    type = string
+variable "account_role_prefix" {
+  type = string
 }
 
-variable ocm_environment {
-    type = string
-    default = "production"
+variable "ocm_environment" {
+  type    = string
+  default = "production"
+}
+
+variable "tags" {
+  description = "(optional) List of aws resource tags to apply."
+  type        = map(string)
+  default = {
+    contact     = "xyz@company.com"
+    cost-center = "12345"
+    owner       = "productteam"
+    environment = "test"
+  }
 }

--- a/examples/operator_roles_and_oidc/create_rosa_sts_operator_roles_and_oidc.tf
+++ b/examples/operator_roles_and_oidc/create_rosa_sts_operator_roles_and_oidc.tf
@@ -13,24 +13,25 @@ terraform {
 
 provider "ocm" {
   token = var.token
-  url = var.url
+  url   = var.url
 }
 
 data "ocm_rosa_operator_roles" "operator_roles" {
   operator_role_prefix = var.operator_role_prefix
-  account_role_prefix = var.account_role_prefix
+  account_role_prefix  = var.account_role_prefix
 }
 
-module operator_roles {
-    source = "terraform-redhat/rosa-sts/aws"
-    version = "0.0.4"
+module "operator_roles" {
+  source  = "terraform-redhat/rosa-sts/aws"
+  version = "0.0.4"
 
-   create_operator_roles = true
-   create_oidc_provider = false
-   create_account_roles = false
+  create_operator_roles = true
+  create_oidc_provider  = false
+  create_account_roles  = false
 
-    cluster_id = var.cluster_id
-    rh_oidc_provider_thumbprint = var.oidc_thumbprint
-    rh_oidc_provider_url = var.oidc_endpoint_url
-    operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  cluster_id                  = var.cluster_id
+  rh_oidc_provider_thumbprint = var.oidc_thumbprint
+  rh_oidc_provider_url        = var.oidc_endpoint_url
+  operator_roles_properties   = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+  tags                        = var.tags
 }

--- a/examples/operator_roles_and_oidc/variables.tf
+++ b/examples/operator_roles_and_oidc/variables.tf
@@ -30,7 +30,7 @@ variable "url" {
 }
 
 variable "tags" {
-  description = "(optional) List of aws resource tags to apply."
+  description = "(optional) List of AWS resource tags to apply."
   type        = map(string)
   default = {
     contact     = "xyz@company.com"

--- a/examples/operator_roles_and_oidc/variables.tf
+++ b/examples/operator_roles_and_oidc/variables.tf
@@ -1,30 +1,41 @@
-variable token {
-  type = string
+variable "token" {
+  type      = string
   sensitive = true
 }
 
-variable operator_role_prefix {
-    type = string
+variable "operator_role_prefix" {
+  type = string
 }
 
-variable cluster_id {
-    type = string
+variable "cluster_id" {
+  type = string
 }
 
-variable oidc_endpoint_url {
-    type = string
+variable "oidc_endpoint_url" {
+  type = string
 }
 
-variable oidc_thumbprint {
-    type = string
+variable "oidc_thumbprint" {
+  type = string
 }
 
-variable account_role_prefix {
-    type = string
-    default = ""
+variable "account_role_prefix" {
+  type    = string
+  default = ""
 }
 
-variable url {
-    type = string
-    default = "https://api.openshift.com"
+variable "url" {
+  type    = string
+  default = "https://api.openshift.com"
+}
+
+variable "tags" {
+  description = "(optional) List of aws resource tags to apply."
+  type        = map(string)
+  default = {
+    contact     = "xyz@company.com"
+    cost-center = "12345"
+    owner       = "productteam"
+    environment = "test"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -7,31 +7,34 @@ terraform {
   }
 }
 
-module rosa_operator_roles {
-    source = "./operator_roles_creation"
-    count = var.create_operator_roles ? 1 : 0
+module "rosa_operator_roles" {
+  source = "./operator_roles_creation"
+  count  = var.create_operator_roles ? 1 : 0
 
-    cluster_id = var.cluster_id
-    rh_oidc_provider_url = var.rh_oidc_provider_url
-    operator_roles_properties = var.operator_roles_properties
+  cluster_id                = var.cluster_id
+  rh_oidc_provider_url      = var.rh_oidc_provider_url
+  operator_roles_properties = var.operator_roles_properties
+  tags                      = var.tags
 }
 
-module rosa_oidc_provider {
-    source ="./oidc_provider_creation"
-    count = var.create_oidc_provider ? 1:0
+module "rosa_oidc_provider" {
+  source = "./oidc_provider_creation"
+  count  = var.create_oidc_provider ? 1 : 0
 
-    rh_oidc_provider_url = var.rh_oidc_provider_url
-    rh_oidc_provider_thumbprint = var.rh_oidc_provider_thumbprint
-    cluster_id = var.cluster_id
+  rh_oidc_provider_url        = var.rh_oidc_provider_url
+  rh_oidc_provider_thumbprint = var.rh_oidc_provider_thumbprint
+  cluster_id                  = var.cluster_id
+  tags                        = var.tags
 }
 
-module rosa_account_roles {
-    source = "./account_roles_creation"
-    count = var.create_account_roles ? 1 : 0
+module "rosa_account_roles" {
+  source = "./account_roles_creation"
+  count  = var.create_account_roles ? 1 : 0
 
-    account_role_prefix = var.account_role_prefix
-    rosa_openshift_version = var.rosa_openshift_version
-    ocm_environment = var.ocm_environment
-    account_role_policies = var.account_role_policies
-    operator_role_policies = var.operator_role_policies
+  account_role_prefix    = var.account_role_prefix
+  rosa_openshift_version = var.rosa_openshift_version
+  ocm_environment        = var.ocm_environment
+  account_role_policies  = var.account_role_policies
+  operator_role_policies = var.operator_role_policies
+  tags                   = var.tags
 }

--- a/oidc_provider_creation/README.md
+++ b/oidc_provider_creation/README.md
@@ -55,6 +55,14 @@ module operator_roles {
     cluster_id = var.cluster_id
     rh_oidc_provider_thumbprint = var.oidc_thumbprint
     rh_oidc_provider_url = var.oidc_endpoint_url
+
+    #optional
+    tags                = {
+      contact     = "xyz@company.com"
+      cost-center = "12345"
+      owner       = "productteam"
+      environment = "test"
+    }
 }
 
 ```

--- a/oidc_provider_creation/README.md
+++ b/oidc_provider_creation/README.md
@@ -18,6 +18,19 @@ Terraform AWS ROSA STS
 |cluster_id| string      | Cluster ID                                                                                                                                         | "11111111111111111111111111111111"                                                                        |
 |rh_oidc_provider_url| string      | OIDC provider url                                                                                                                                  | "rh-oidc-staging.s3.us-east-1.amazonaws.com/11111111111111111111111111111111"                             |
 |rh_oidc_provider_thumbprint| string      | Thumbprint for https://rh-oidc.s3.us-east-1.amazonaws.com                                                                                          | "2222222222222222222222222222222222222222"                                                                |
+|tags | map of strings | List of AWS resource tags to apply | [an example can be found below](#tags-object) |
+
+### tags object
+`tags` is a map of strings with resource tags to be applied to AWS resources created.
+The map looks like:
+```
+{
+  contact     = "xyz@company.com"
+  cost-center = "12345"
+  owner       = "productteam"
+  environment = "test"
+}
+```
 
 ## Get OCM Information
 

--- a/oidc_provider_creation/main.tf
+++ b/oidc_provider_creation/main.tf
@@ -6,9 +6,9 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
     "sts.amazonaws.com"
   ]
 
-  tags = {
+  tags = merge(var.tags, {
     rosa_cluster_id = var.cluster_id
-  }
+  })
 
   thumbprint_list = [var.rh_oidc_provider_thumbprint]
 }

--- a/oidc_provider_creation/variables.tf
+++ b/oidc_provider_creation/variables.tf
@@ -17,7 +17,7 @@ variable "rh_oidc_provider_thumbprint" {
 }
 
 variable "tags" {
-  description = "List of aws resource tags to apply."
+  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
 }

--- a/oidc_provider_creation/variables.tf
+++ b/oidc_provider_creation/variables.tf
@@ -1,17 +1,23 @@
-variable cluster_id {
-    description = "cluster ID"
-    type = string
-    default = ""
+variable "cluster_id" {
+  description = "cluster ID"
+  type        = string
+  default     = ""
 }
 
-variable rh_oidc_provider_url {
-    description = "oidc provider url"
-    type = string
-    default = "rh-oidc.s3.us-east-1.amazonaws.com"
+variable "rh_oidc_provider_url" {
+  description = "oidc provider url"
+  type        = string
+  default     = "rh-oidc.s3.us-east-1.amazonaws.com"
 }
 
-variable rh_oidc_provider_thumbprint {
-    description = "Thumbprint for the variable `rh_oidc_provider_url`"
-    type = string
-    default = "917e732d330f9a12404f73d8bea36948b929dffc"
+variable "rh_oidc_provider_thumbprint" {
+  description = "Thumbprint for the variable `rh_oidc_provider_url`"
+  type        = string
+  default     = "917e732d330f9a12404f73d8bea36948b929dffc"
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }

--- a/operator_roles_creation/README.md
+++ b/operator_roles_creation/README.md
@@ -18,7 +18,7 @@ Terraform AWS ROSA STS
 |cluster_id| string      | Cluster ID                                                                                                                                         | "11111111111111111111111111111111"                                                                        |
 |rh_oidc_provider_url| string      | OIDC provider url                                                                                                                                  | "rh-oidc-staging.s3.us-east-1.amazonaws.com/11111111111111111111111111111111"                             |
 |operator_roles_properties| list of map | List of 6 items of ROSA Operator IAM Roles. Each item should contains: role_name, policy_name, service_accounts, operator_name, operator_namespace | can be found [below](https://github.com/terraform-redhat/terraform-aws-rosa-sts#get-clusters-information) |
-|tags | map of strings |List of aws resource tags to apply | |tags | map of strings |List of AWS resource tags to apply | [an example can be found below](#tags-object) |
+|tags | map of strings |List of AWS resource tags to apply | [an example can be found below](#tags-object) |
 
 ### tags object
 `tags` is a map of strings with resource tags to be applied to AWS resources created.

--- a/operator_roles_creation/README.md
+++ b/operator_roles_creation/README.md
@@ -60,6 +60,14 @@ module operator_roles {
     cluster_id = ocm_cluster_rosa_classic.rosa_sts_cluster.id
     rh_oidc_provider_url = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
     operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+
+    #optional
+    tags                = {
+      contact     = "xyz@company.com"
+      cost-center = "12345"
+      owner       = "productteam"
+      environment = "test"
+    }
 }
 ```
 

--- a/operator_roles_creation/README.md
+++ b/operator_roles_creation/README.md
@@ -18,6 +18,19 @@ Terraform AWS ROSA STS
 |cluster_id| string      | Cluster ID                                                                                                                                         | "11111111111111111111111111111111"                                                                        |
 |rh_oidc_provider_url| string      | OIDC provider url                                                                                                                                  | "rh-oidc-staging.s3.us-east-1.amazonaws.com/11111111111111111111111111111111"                             |
 |operator_roles_properties| list of map | List of 6 items of ROSA Operator IAM Roles. Each item should contains: role_name, policy_name, service_accounts, operator_name, operator_namespace | can be found [below](https://github.com/terraform-redhat/terraform-aws-rosa-sts#get-clusters-information) |
+|tags | map of strings |List of aws resource tags to apply | |tags | map of strings |List of AWS resource tags to apply | [an example can be found below](#tags-object) |
+
+### tags object
+`tags` is a map of strings with resource tags to be applied to AWS resources created.
+The map looks like:
+```
+{
+  contact     = "xyz@company.com"
+  cost-center = "12345"
+  owner       = "productteam"
+  environment = "test"
+}
+```
 
 ## Get OCM Information
 

--- a/operator_roles_creation/main.tf
+++ b/operator_roles_creation/main.tf
@@ -7,11 +7,12 @@ terraform {
   }
 }
 
-module rosa_operator_roles {
-    source = "./operator_roles"
-    count = 6
+module "rosa_operator_roles" {
+  source = "./operator_roles"
+  count  = 6
 
-    cluster_id = var.cluster_id
-    rh_oidc_provider_url = var.rh_oidc_provider_url
-    operator_role_properties = var.operator_roles_properties[count.index]
+  cluster_id               = var.cluster_id
+  rh_oidc_provider_url     = var.rh_oidc_provider_url
+  operator_role_properties = var.operator_roles_properties[count.index]
+  tags                     = var.tags
 }

--- a/operator_roles_creation/operator_roles/operator_role_resource.tf
+++ b/operator_roles_creation/operator_roles/operator_role_resource.tf
@@ -9,9 +9,9 @@ resource "aws_iam_role" "operator_role" {
         Action = "sts:AssumeRoleWithWebIdentity"
         Effect = "Allow"
         Condition = {
-            StringEquals = {
-                "${var.rh_oidc_provider_url}:sub" = var.operator_role_properties.service_accounts
-            }
+          StringEquals = {
+            "${var.rh_oidc_provider_url}:sub" = var.operator_role_properties.service_accounts
+          }
         }
         Principal = {
           Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${var.rh_oidc_provider_url}"
@@ -20,16 +20,16 @@ resource "aws_iam_role" "operator_role" {
     ]
   })
 
-  tags = {
-    red-hat-managed = true
-    rosa_cluster_id = var.cluster_id
+  tags = merge(var.tags, {
+    red-hat-managed    = true
+    rosa_cluster_id    = var.cluster_id
     operator_namespace = var.operator_role_properties.operator_namespace
-    operator_name = var.operator_role_properties.operator_name
-  }
+    operator_name      = var.operator_role_properties.operator_name
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "operator_role_policy_attachment" {
-  role = aws_iam_role.operator_role.name
+  role       = aws_iam_role.operator_role.name
   policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.operator_role_properties.policy_name}"
 }
 

--- a/operator_roles_creation/operator_roles/variables.tf
+++ b/operator_roles_creation/operator_roles/variables.tf
@@ -1,21 +1,27 @@
-variable cluster_id {
-    description = "cluster ID"
-    type = string
+variable "cluster_id" {
+  description = "cluster ID"
+  type        = string
 }
 
-variable rh_oidc_provider_url {
-    description = "oidc provider url"
-    type = string
-    default = "rh-oidc.s3.us-east-1.amazonaws.com"
+variable "rh_oidc_provider_url" {
+  description = "oidc provider url"
+  type        = string
+  default     = "rh-oidc.s3.us-east-1.amazonaws.com"
 }
 
-variable operator_role_properties {
-    description = ""
-    type = object({
-        role_name = string
-        policy_name = string
-        service_accounts = list(string)
-        operator_name = string
-        operator_namespace = string
-    })
+variable "operator_role_properties" {
+  description = ""
+  type = object({
+    role_name          = string
+    policy_name        = string
+    service_accounts   = list(string)
+    operator_name      = string
+    operator_namespace = string
+  })
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }

--- a/operator_roles_creation/operator_roles/variables.tf
+++ b/operator_roles_creation/operator_roles/variables.tf
@@ -21,7 +21,7 @@ variable "operator_role_properties" {
 }
 
 variable "tags" {
-  description = "List of aws resource tags to apply."
+  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
 }

--- a/operator_roles_creation/variables.tf
+++ b/operator_roles_creation/variables.tf
@@ -1,25 +1,31 @@
-variable cluster_id {
-    description = "cluster ID"
-    type = string
+variable "cluster_id" {
+  description = "cluster ID"
+  type        = string
 }
 
-variable rh_oidc_provider_url {
-    description = "oidc provider url"
-    type = string
-    default = "rh-oidc.s3.us-east-1.amazonaws.com"
+variable "rh_oidc_provider_url" {
+  description = "oidc provider url"
+  type        = string
+  default     = "rh-oidc.s3.us-east-1.amazonaws.com"
 }
 
-variable operator_roles_properties {
-    description = "List of ROSA Operator IAM Roles"
-    type = list(object({
-        role_name = string
-        policy_name = string
-        service_accounts = list(string)
-        operator_name = string
-        operator_namespace = string
-    }))
-    validation {
-      condition     = length(var.operator_roles_properties) == 6
-      error_message = "The list of operator roles should contains 6 elements."
-    }
+variable "operator_roles_properties" {
+  description = "List of ROSA Operator IAM Roles"
+  type = list(object({
+    role_name          = string
+    policy_name        = string
+    service_accounts   = list(string)
+    operator_name      = string
+    operator_namespace = string
+  }))
+  validation {
+    condition     = length(var.operator_roles_properties) == 6
+    error_message = "The list of operator roles should contains 6 elements."
+  }
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }

--- a/operator_roles_creation/variables.tf
+++ b/operator_roles_creation/variables.tf
@@ -25,7 +25,7 @@ variable "operator_roles_properties" {
 }
 
 variable "tags" {
-  description = "List of aws resource tags to apply."
+  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,84 +1,90 @@
-variable cluster_id {
-    description = "cluster ID"
-    type = string
-    default = ""
+variable "cluster_id" {
+  description = "cluster ID"
+  type        = string
+  default     = ""
 }
 
-variable rh_oidc_provider_url {
-    description = "oidc provider url"
-    type = string
-    default = "rh-oidc.s3.us-east-1.amazonaws.com"
+variable "rh_oidc_provider_url" {
+  description = "oidc provider url"
+  type        = string
+  default     = "rh-oidc.s3.us-east-1.amazonaws.com"
 }
 
-variable operator_roles_properties {
-    description = "List of ROSA Operator IAM Roles"
-    type = list(object({
-        role_name = string
-        policy_name = string
-        service_accounts = list(string)
-        operator_name = string
-        operator_namespace = string
-    }))
-    default = []
+variable "operator_roles_properties" {
+  description = "List of ROSA Operator IAM Roles"
+  type = list(object({
+    role_name          = string
+    policy_name        = string
+    service_accounts   = list(string)
+    operator_name      = string
+    operator_namespace = string
+  }))
+  default = []
 }
 
-variable create_operator_roles {
-    description = "When using BYO OIDC and reusing the operator roles set to false so as not to create operator roles"
-    type = bool
+variable "create_operator_roles" {
+  description = "When using BYO OIDC and reusing the operator roles set to false so as not to create operator roles"
+  type        = bool
 }
 
-variable create_oidc_provider {
-    description = "When using BYO OIDC and reusing the OIDC provider set to false so as not to create identity provider"
-    type = bool
+variable "create_oidc_provider" {
+  description = "When using BYO OIDC and reusing the OIDC provider set to false so as not to create identity provider"
+  type        = bool
 }
 
-variable create_account_roles {
-    description = "This attribute determines whether the module should create account roles or not"
-    type = bool
+variable "create_account_roles" {
+  description = "This attribute determines whether the module should create account roles or not"
+  type        = bool
 }
 
-variable rh_oidc_provider_thumbprint {
-    description = "Thumbprint for https://rh-oidc.s3.us-east-1.amazonaws.com"
-    type = string
-    default = "917e732d330f9a12404f73d8bea36948b929dffc"
+variable "rh_oidc_provider_thumbprint" {
+  description = "Thumbprint for https://rh-oidc.s3.us-east-1.amazonaws.com"
+  type        = string
+  default     = "917e732d330f9a12404f73d8bea36948b929dffc"
 }
 
-variable account_role_prefix {
-    type = string
-    default = ""
+variable "account_role_prefix" {
+  type    = string
+  default = ""
 }
 
-variable rosa_openshift_version {
-    type = string
-    default = "4.12"
+variable "rosa_openshift_version" {
+  type    = string
+  default = "4.12"
 }
 
-variable ocm_environment {
-    description = "The OCM environments should be one of those: production, staging, integration, local"
-    type = string
-    default = ""
+variable "ocm_environment" {
+  description = "The OCM environments should be one of those: production, staging, integration, local"
+  type        = string
+  default     = ""
 }
 
-variable account_role_policies {
-    description = "account role policies details for account roles creation"
-    type =object({
-        sts_installer_permission_policy = string
-        sts_support_permission_policy = string
-        sts_instance_worker_permission_policy = string
-        sts_instance_controlplane_permission_policy = string
-    })
-    default = null
+variable "account_role_policies" {
+  description = "account role policies details for account roles creation"
+  type = object({
+    sts_installer_permission_policy             = string
+    sts_support_permission_policy               = string
+    sts_instance_worker_permission_policy       = string
+    sts_instance_controlplane_permission_policy = string
+  })
+  default = null
 }
 
-variable operator_role_policies {
-    description = "operator role policies details for operator roles creation"
-    type =object({
-        openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy = string
-        openshift_cloud_network_config_controller_cloud_credentials_policy = string
-        openshift_cluster_csi_drivers_ebs_cloud_credentials_policy = string
-        openshift_image_registry_installer_cloud_credentials_policy = string
-        openshift_ingress_operator_cloud_credentials_policy = string
-        openshift_machine_api_aws_cloud_credentials_policy = string
-    })
-    default = null
+variable "operator_role_policies" {
+  description = "operator role policies details for operator roles creation"
+  type = object({
+    openshift_cloud_credential_operator_cloud_credential_operator_iam_ro_creds_policy = string
+    openshift_cloud_network_config_controller_cloud_credentials_policy                = string
+    openshift_cluster_csi_drivers_ebs_cloud_credentials_policy                        = string
+    openshift_image_registry_installer_cloud_credentials_policy                       = string
+    openshift_ingress_operator_cloud_credentials_policy                               = string
+    openshift_machine_api_aws_cloud_credentials_policy                                = string
+  })
+  default = null
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -84,7 +84,7 @@ variable "operator_role_policies" {
 }
 
 variable "tags" {
-  description = "List of aws resource tags to apply."
+  description = "List of AWS resource tags to apply."
   type        = map(string)
   default     = null
 }


### PR DESCRIPTION
when using terraform module the resources created will not have any resource tags. in most cases organizations need certain mandatory tagging for billing or categorizng resources to particular application or team. this PR will in clude tags as parameter so they can be passed to module. 


https://github.com/terraform-redhat/terraform-aws-rosa-sts/issues/8