### PR TITLE
OCM-2237: path variable should be added to instance_account_role_resource

### DIFF
--- a/account_roles_creation/account_role/instance_account_role_resource.tf
+++ b/account_roles_creation/account_role/instance_account_role_resource.tf
@@ -2,6 +2,7 @@
 # role
 resource "aws_iam_role" "instance_account_role" {
   name                 = "${var.account_role_prefix}-${var.instance_account_role_properties.role_name}-Role"
+  path                 = var.path
   permissions_boundary = var.permissions_boundary
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
Fixing issue was introduced in https://github.com/terraform-redhat/terraform-aws-rosa-sts/pull/17
The path was passed only to `account_role_resource` and not to `instance_account_role_resource`