### PR TITLE
OCM-2415: Supporting creating account roles with minor versions only

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "account_role_prefix" {
 variable "rosa_openshift_version" {
   description = "Desired version of OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled."
   type        = string
-  default     = "4.13.0"
+  default     = ""
 }
 
 variable "ocm_environment" {


### PR DESCRIPTION
Changed the validation in create account roles to support only minor version (<patch_version>.<minor_version> format)
In case the user supplies a version but doesn't supply all_versions data source he will get the error:
![image](https://github.com/terraform-redhat/terraform-aws-rosa-sts/assets/35330069/2d8b2898-7df6-491a-aa4a-9fd8bb30c257)

In case the user supplies version and the all_versions data source but it's not supported version he will get the error:
![image](https://github.com/terraform-redhat/terraform-aws-rosa-sts/assets/35330069/f580064c-0d93-4262-bcf9-142a277691f9)

In case the user didn't supply the version it will set the version by default to 4.13 and the all_versions data source is not required
